### PR TITLE
12.0 Misc. UI improvements

### DIFF
--- a/pattern_import_export/models/base.py
+++ b/pattern_import_export/models/base.py
@@ -34,7 +34,7 @@ class Base(models.AbstractModel):
         web = "/web#"
         args = [
             "action="
-            + str(self.env.ref("pattern_import_export.action_patterned_import").id),
+            + str(self.env.ref("pattern_import_export.action_patterned_imports").id),
             "id=" + str(export.id),
             "model=patterned.import.export",
             "view_type=form",

--- a/pattern_import_export/models/ir_exports.py
+++ b/pattern_import_export/models/ir_exports.py
@@ -289,9 +289,10 @@ class IrExports(models.Model):
             .env[self.model_id.model]
             .load([], datas)
         )
-        patterned_import.info, patterned_import.info_detail, patterned_import.status = self._process_load_result(
-            patterned_import, res
-        )
+        load_result = self._process_load_result(patterned_import, res)
+        patterned_import.info = load_result[0]
+        patterned_import.info_detail = load_result[1]
+        patterned_import.status = load_result[2]
         return self._notify_user(patterned_import)
 
     def _notify_user(self, patterned_import_export):

--- a/pattern_import_export/models/ir_exports.py
+++ b/pattern_import_export/models/ir_exports.py
@@ -168,6 +168,7 @@ class IrExports(models.Model):
                 "datas_fname": name,
                 "kind": "export",
                 "status": "success",
+                "export_id": self.id,
             }
         )
 

--- a/pattern_import_export/models/ir_exports.py
+++ b/pattern_import_export/models/ir_exports.py
@@ -30,6 +30,50 @@ class IrExports(models.Model):
         string="Pattern last generation date", readonly=True
     )
     export_format = fields.Selection(selection=[])
+    count_pattimpex_fail = fields.Integer(compute="_compute_pattimpex_counts")
+    count_pattimpex_pending = fields.Integer(compute="_compute_pattimpex_counts")
+    count_pattimpex_success = fields.Integer(compute="_compute_pattimpex_counts")
+    pattimpex_ids = fields.One2many("patterned.import.export", "export_id")
+
+    def _compute_pattimpex_counts(self):
+        for rec in self:
+            for state in ("fail", "pending", "success"):
+                field_name = "count_pattimpex_" + state
+                count = len(rec.pattimpex_ids.filtered(lambda r: r.status == state).ids)
+                setattr(rec, field_name, count)
+
+    def button_open_pattimpex_fail(self):
+        ids = self.pattimpex_ids.filtered(lambda r: r.status == "fail").ids
+        return {
+            "name": _("Patterned imports/exports"),
+            "view_type": "form",
+            "view_mode": "tree,form",
+            "res_model": "patterned.import.export",
+            "type": "ir.actions.act_window",
+            "domain": [("id", "in", ids)],
+        }
+
+    def button_open_pattimpex_pending(self):
+        ids = self.pattimpex_ids.filtered(lambda r: r.status == "pending").ids
+        return {
+            "name": _("Patterned imports/exports"),
+            "view_type": "form",
+            "view_mode": "tree,form",
+            "res_model": "patterned.import.export",
+            "type": "ir.actions.act_window",
+            "domain": [("id", "in", ids)],
+        }
+
+    def button_open_pattimpex_success(self):
+        ids = self.pattimpex_ids.filtered(lambda r: r.status == "success").ids
+        return {
+            "name": _("Patterned imports/exports"),
+            "view_type": "form",
+            "view_mode": "tree,form",
+            "res_model": "patterned.import.export",
+            "type": "ir.actions.act_window",
+            "domain": [("id", "in", ids)],
+        }
 
     @property
     def row_start_records(self):

--- a/pattern_import_export/models/ir_exports.py
+++ b/pattern_import_export/models/ir_exports.py
@@ -218,14 +218,15 @@ class IrExports(models.Model):
 
     def _process_load_result(self, patterned_import, res):
         ids = res["ids"] or []
-        info = _("Number of record imported {}\ndetails {}").format(len(ids), ids)
+        info = _("Number of record imported {}").format(len(ids))
+        info_detail = _("Details: {}".format(ids))
         if res.get("messages"):
             info += self._process_load_message(res["messages"])
         if res.get("messages"):
             status = "fail"
         else:
             status = "success"
-        return info, status
+        return info, info_detail, status
 
     @job(default_channel="root.importwithpattern")
     def _generate_import_with_pattern_job(self, patterned_import):
@@ -234,7 +235,8 @@ class IrExports(models.Model):
             datas = self._read_import_data(attachment_data)
         except Exception as e:
             patterned_import.status = "fail"
-            patterned_import.info = e
+            patterned_import.info = _("Failed (check details)")
+            patterned_import.info_detail = e
         res = (
             self.with_context(
                 load_format="flatty", pattern_import_export_model=self.model_id.model
@@ -242,7 +244,7 @@ class IrExports(models.Model):
             .env[self.model_id.model]
             .load([], datas)
         )
-        patterned_import.info, patterned_import.status = self._process_load_result(
+        patterned_import.info, patterned_import.info_detail, patterned_import.status = self._process_load_result(
             patterned_import, res
         )
         return self._notify_user(patterned_import)

--- a/pattern_import_export/models/patterned_import_export.py
+++ b/pattern_import_export/models/patterned_import_export.py
@@ -17,3 +17,4 @@ class PatternedImportExport(models.Model):
     info = fields.Char()
     info_detail = fields.Char()
     kind = fields.Selection([("import", "import"), ("export", "export")], required=True)
+    export_id = fields.Many2one("ir.exports", required=True, string="Export pattern")

--- a/pattern_import_export/models/patterned_import_export.py
+++ b/pattern_import_export/models/patterned_import_export.py
@@ -15,4 +15,5 @@ class PatternedImportExport(models.Model):
         default="pending",
     )
     info = fields.Char()
+    info_detail = fields.Char()
     kind = fields.Selection([("import", "import"), ("export", "export")], required=True)

--- a/pattern_import_export/tests/common.py
+++ b/pattern_import_export/tests/common.py
@@ -79,6 +79,7 @@ class ExportPatternCommon(JobMixin):
                 "datas_fname": "a_file_name",
                 "name": "a_file_name",
                 "kind": "export",  # not always true but doesn't matter
+                "export_id": cls.env["ir.exports"].search([])[0].id,  # doesn't matter
             }
         )
 

--- a/pattern_import_export/views/pattern_import_export.xml
+++ b/pattern_import_export/views/pattern_import_export.xml
@@ -10,6 +10,33 @@
                 <header>
                     <button name="%(import_pattern_wizard_action)d" string="Import" class="oe_highlight" type="action" context="{'default_ir_exports_id': id, 'hide_ir_export_id': True}"/>
                 </header>
+                <div class="oe_button_box" name="button_box">
+                    <button name="button_open_pattimpex_fail" type="object" class="oe_stat_button" icon="fa-link">
+                        <div class="o_field_widget o_stat_info">
+                            <span class="o_stat_value">
+                                <field name="count_pattimpex_fail" widget="statinfo" nolabel="1"/>
+                            </span>
+                            <span class="o_stat_text">Fail</span>
+                        </div>
+                    </button>
+                    <button name="button_open_pattimpex_pending" type="object" class="oe_stat_button" icon="fa-link">
+                        <div class="o_field_widget o_stat_info">
+                            <span class="o_stat_value">
+                                <field name="count_pattimpex_pending" widget="statinfo" nolabel="1"/>
+                            </span>
+                            <span class="o_stat_text">Pending</span>
+                        </div>
+                    </button>
+                    <button name="button_open_pattimpex_success" type="object" class="oe_stat_button" icon="fa-link">
+                        <div class="o_field_widget o_stat_info">
+                            <span class="o_stat_value">
+                                <field name="count_pattimpex_success" widget="statinfo" nolabel="1"/>
+                            </span>
+                            <span class="o_stat_text">Success</span>
+                        </div>
+                    </button>
+                </div>
+
             </xpath>
             <xpath expr="//form/group[1]" position="after">
                 <group>

--- a/pattern_import_export/views/patterned_import_export.xml
+++ b/pattern_import_export/views/patterned_import_export.xml
@@ -11,6 +11,7 @@
                 <field name="status"/>
                 <field name="kind"/>
                 <field name="info"/>
+                <field name="export_id"/>
             </tree>
         </field>
     </record>
@@ -29,6 +30,7 @@
                         <field name="kind" readonly="1"/>
                         <field name="info" readonly="1"/>
                         <field name="info_detail" readonly="1"/>
+                        <field name="export_id" readonly="1"/>
                     </group>
                 </sheet>
             </form>

--- a/pattern_import_export/views/patterned_import_export.xml
+++ b/pattern_import_export/views/patterned_import_export.xml
@@ -5,7 +5,7 @@
         <field name="name">patterned_import_view_tree</field>
         <field name="model">patterned.import.export</field>
         <field name="arch" type="xml">
-            <tree>
+            <tree create="false">
                 <field name="attachment_id"/>
                 <field name="create_date"/>
                 <field name="status"/>
@@ -20,7 +20,7 @@
         <field name="name">patterned_import_export_view_form</field>
         <field name="model">patterned.import.export</field>
         <field name="arch" type="xml">
-            <form string="patterned_import_export_form">
+            <form string="patterned_import_export_form" create="false">
                 <sheet>
                     <group>
                         <field name="datas" filename="datas_fname" readonly="1"/>

--- a/pattern_import_export/views/patterned_import_export.xml
+++ b/pattern_import_export/views/patterned_import_export.xml
@@ -28,25 +28,43 @@
                         <field name="status" readonly="1"/>
                         <field name="kind" readonly="1"/>
                         <field name="info" readonly="1"/>
+                        <field name="info_detail" readonly="1"/>
                     </group>
                 </sheet>
             </form>
         </field>
     </record>
 
-    <record id="action_patterned_import" model="ir.actions.act_window">
-        <field name="name">Patterned imports/exports</field>
+    <record id="action_patterned_imports" model="ir.actions.act_window">
+        <field name="name">Patterned imports</field>
         <field name="type">ir.actions.act_window</field>
         <field name="res_model">patterned.import.export</field>
         <field name="view_mode">tree,form</field>
+        <field name="domain">[('kind', '=', 'import')]</field>
         <field name="view_type">form</field>
     </record>
 
-    <menuitem id="patterned_import_menu"
-              name="Patterned import/exports"
+    <record id="action_patterned_exports" model="ir.actions.act_window">
+        <field name="name">Patterned exports</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="res_model">patterned.import.export</field>
+        <field name="view_mode">tree,form</field>
+        <field name="domain">[('kind', '=', 'export')]</field>
+        <field name="view_type">form</field>
+    </record>
+
+    <menuitem id="patterned_imports_menu"
+              name="Patterned imports"
               parent="import_export_menu_root"
               sequence="3"
               groups="base.group_user"
-              action="action_patterned_import"/>
+              action="action_patterned_imports"/>
+
+    <menuitem id="patterned_export_menu"
+              name="Patterned exports"
+              parent="import_export_menu_root"
+              sequence="4"
+              groups="base.group_user"
+              action="action_patterned_exports"/>
 
 </odoo>

--- a/pattern_import_export/wizard/import_pattern_wizard.py
+++ b/pattern_import_export/wizard/import_pattern_wizard.py
@@ -44,6 +44,7 @@ class ImportPatternWizard(models.TransientModel):
                 "datas": self.import_file,
                 "datas_fname": self.filename,
                 "kind": "import",
+                "export_id": self.ir_exports_id.id,
             }
         )
         self.ir_exports_id.with_delay(

--- a/pattern_import_export_xlsx/__manifest__.py
+++ b/pattern_import_export_xlsx/__manifest__.py
@@ -11,6 +11,6 @@
     "depends": ["pattern_import_export"],
     "external_dependencies": {"python": ["openpyxl"]},
     "demo": ["demo/demo.xml"],
-    "data": [],
+    "data": ["views/ir_exports.xml"],
     "installable": True,
 }

--- a/pattern_import_export_xlsx/models/ir_exports.py
+++ b/pattern_import_export_xlsx/models/ir_exports.py
@@ -185,13 +185,10 @@ class IrExports(models.Model):
         wb.save(output)
         attachment.datas = base64.b64encode(output.getvalue())
         ids = res["ids"] or []
-        info = _(
-            "Number of record imported {} Number of error/warning {}"
-            "\nrecord ids details: {}"
-            "\n{}"
-        ).format(
-            len(ids),
-            len(res.get("messages", [])),
+        info = _("Number of record imported {} Number of error/warning {}").format(
+            len(ids), len(res.get("messages", []))
+        )
+        info_detail = _("Record ids: {}" "\nDetails: {}").format(
             ids,
             "\n".join(
                 [
@@ -204,7 +201,7 @@ class IrExports(models.Model):
             status = "fail"
         else:
             status = "success"
-        return info, status
+        return info, info_detail, status
 
     def _process_load_result(self, attachment, res):
         if self.export_format == "xlsx":

--- a/pattern_import_export_xlsx/views/ir_exports.xml
+++ b/pattern_import_export_xlsx/views/ir_exports.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="ir_exports_form_view" model="ir.ui.view">
+        <field name="model">ir.exports</field>
+        <field name="inherit_id" ref="base_export_manager.ir_exports_form_view"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='export_fields']" position="after">
+                <group name="excel_parameters" string="Excel parameters">
+                    <field name="tab_to_import"/>
+                </group>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/pattern_import_export_xlsx/views/ir_exports.xml
+++ b/pattern_import_export_xlsx/views/ir_exports.xml
@@ -4,11 +4,9 @@
         <field name="model">ir.exports</field>
         <field name="inherit_id" ref="base_export_manager.ir_exports_form_view"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='export_fields']" position="after">
-                <group name="excel_parameters" string="Excel parameters">
-                    <field name="tab_to_import"/>
-                </group>
-            </xpath>
+            <field name="export_format" position="after">
+                <field name="tab_to_import" attrs="{'invisible': [('export_format', '!=', 'xlsx')], 'required': [('export_format', '=', 'xlsx')]}"/>
+            </field>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
following https://github.com/shopinvader/pattern-import-export/pull/22#issuecomment-696348989

> TODO @kevinkhao
> 
> * [ ]  improve UI split import/export menu in two

new menu

![Screenshot from 2020-09-23 19-39-58](https://user-images.githubusercontent.com/19902174/94049001-9bfa7d00-fdd4-11ea-850c-5eecabe3a3c3.png)


> * [ ]  import patterned split result in two field (too avoid a long list of ids in the tree view)

form changed

![Screenshot from 2020-09-23 19-40-34](https://user-images.githubusercontent.com/19902174/94049051-b2a0d400-fdd4-11ea-895d-e20f72dbf639.png)

tree unchanged

![Screenshot from 2020-09-23 19-40-32](https://user-images.githubusercontent.com/19902174/94049071-bdf3ff80-fdd4-11ea-8930-1c9cfc05c229.png)

> * [ ]  add smart button on ir.exports menu (with number of done/fail/pending)

combining all stats into one button looked terrible and seems complicated to accomodate
![Screenshot from 2020-09-23 19-15-22](https://user-images.githubusercontent.com/19902174/94049109-d06e3900-fdd4-11ea-9c16-7864cb95cddf.png)

split into 3 instead

![Screenshot from 2020-09-23 19-26-35](https://user-images.githubusercontent.com/19902174/94049163-e3810900-fdd4-11ea-8b20-f67fb38a1c84.png)

> * [ ]  add missing tab_to_import in view

ir.export form view has new section

![Screenshot from 2020-09-23 19-42-39](https://user-images.githubusercontent.com/19902174/94049214-fabff680-fdd4-11ea-924a-feb51dd21f6c.png)

> * [ ]  in the tree/form view of partterned import add the link of the pattern

current state:

![Screenshot from 2020-09-23 19-43-32](https://user-images.githubusercontent.com/19902174/94049303-1b884c00-fdd5-11ea-9032-899c60916658.png)

There is a OCA module to turn any m2o to a clickable link in tree view; but by default that applies to every m2o in every view. Should I add it as a dependency ? 
Although the setting can be changed, this will impact every other tree view if we don't change defaults to not use that widget.