### PR TITLE
[FIX] Consistent import/export on db ids, no external ids

### DIFF
--- a/pattern_import_export/README.rst
+++ b/pattern_import_export/README.rst
@@ -19,67 +19,92 @@ Pattern Import Export
 
 |badge1| |badge2| |badge3| 
 
-This module allows to create some patterns to export records.
-A pattern is defined by a list of fields to export.
-This module only create a common data structure used to do the real export into the expected format.
+Overview
+~~~~~~~~
 
-The import is also implemented to create or update records.
-Fields to update (or create) shouldn't be necessarily into the pattern (but the base model should match).
-That means if your pattern only contains the name field, you can also update others fields without updating your pattern.
+This module extends the import/export capabilities of Odoo.
+
+Patterns are simply a type of ir.exports model, so you can define them with the native Odoo widget to define export lists.
+
+This module only create a common data structure. Other modules will be used to add specific file type support like excel and csv.
+
+
+Features
+--------
+
+* Key matching: instead of always using IDs, match keys to unique-constrained fields, for example update a product by
+  specifying its product_code instead of its database ID or external ID
+
+* One2many and Many2many support: create or update for example invoice lines with a syntax that is very readable and easy to update
+
+* As long as you respect the appropriate format and field names, you are free to add/remove/rename columns, even if they
+  are not in the initial Pattern used for the export
 
 **Table of contents**
 
 .. contents::
    :local:
 
+Configuration
+=============
+
+* Install another module that supports a specific file type
+* Use the Patterns menu to configure your import/export formats
+
 Usage
 =====
 
-Functionally
-~~~~~~~~~~~~
-To use this module, you only have to install it (please check python dependencies).
-
+Configuring a pattern
+~~~~~~~~~~~~~~~~~~~~~
 First you have to define a pattern:
 
-1. Go on the Import/Export->Patterns menu;
-2. Create your pattern with fields to export.
+1. Go on the Import/Export->Patterns menu
+2. Create your pattern with fields to export
+
+You can refer to the examples in demo data.
 
 
-Do export
+Exporting
 ---------
-On a Tree view, select records to export (or into the Form view) and on the
-"action" options, pick the "Export with pattern".
-On the new wizard, fill the Export pattern to use and click on the "Export button".
+* Open the tree view of any model and tick some record selection boxes.
+* In the sidebar, click on the "Export with Pattern" button
+* Select the pattern that you wish to use, click export and download the generated file.
+* A "Patterned Import/Export" is created, and its job along with it. Depending on the success or failure of the job,
+  you will receive a red/green notification on your window.
 
-A job is now created and your export will be executed as soon as possible (depending on system charge).
 
-Do import
+Importing
 ---------
-Once your file is edited, you can upload it to create or update related records.
+You have two options:
 
-On a Tree view, select at least one record (not necessarily ones to update) and on the "action" button, select "Import with pattern".
-A new wizard is open and select a pattern to do the import.
+* Open the tree view of any model and tick some record selection boxes (for this step, these don't matter, we only just want to show the sidebar).
+* In the sidebar, click on the "Import with Pattern" button
+* Select the pattern that you used to generate the export, upload your file and click import.
+* A "Patterned Import/Export" is created, and its job along with it. Depending on the success or failure of the job, you
+  will receive a red/green notification on your window. You can check the details in the appropriate Import/Export menu.
 
-Into your file, you can add/remove/rename column as you want (with specific format and with existing field's name).
+Or:
 
-You can also add some fields wo aren't into the pattern and these fields' will be updated.
+* Access the Import wizard through the Import/Export menu
+* Select the Pattern that you want to use
+* Click on the "Import" button
 
-To be more user-friendly, it's not mandatory to work with ID or XML ID to update existing record.
-You can just add "/key" at the end of the column name (without spaces) and the column will become the key (please ensure the field used as key as necessary constraints).
+Example
+-------
 
-Example of simple update on ``product.product``:
+Here is an example of a simple update on ``product.product``:
 Existing record:
 
-- xml id: "__export__.product1"
+- id: 10
 - name: "Product 1"
 - default_code: "PRD1"
 
-The generated export should be like
+The generated export will look like:
 
 +---------------------+-----------+--------------+
 | id                  | name      | default_code |
 +=====================+===========+==============+
-| __export__.product1 | Product 1 | PRD1         |
+| 10                  | Product 1 | PRD1         |
 +---------------------+-----------+--------------+
 
 Updated file
@@ -87,53 +112,50 @@ Updated file
 +---------------------+---------------+--------------+
 | id                  | name          | default_code |
 +=====================+===============+==============+
-| __export__.product1 | Product 1-bis | PRD1B        |
+| 10                  | Product 1-bis | PRD1B        |
 +---------------------+---------------+--------------+
 
-Then your record will be updated:
+After import, our record will have been updated:
 
 - xml id: "__export__.product1"
 - name: "Product 1-bis"
 - default_code: "PRD1B"
 
-On the same example, you can also edit more complex fields like relational fields:
+Now, let's update some relational fields. Here is some more of our starting data:
 
 - seller_ids:
 
- - xml id (of the seller/partner): "__export__.partner1"
+ - id (of the seller_id which is a res.partner): 22
  - name (seller): Partner 1
  - price: 10
 
 The generated export should be like
 
 +---------------------+-----------+--------------+----------------------+--------------------+
-| id                  | name      | default_code | seller_ids|1|name|id | seller_ids|1|price |
+| id                  | name      | default_code | seller_ids|1|id      | seller_ids|1|price |
 +=====================+===========+==============+======================+====================+
-| __export__.product1 | Product 1 | PRD1         | __export__.partner1  | 10                 |
+| 10                  | Product 1 | PRD1         | 22                   | 10                 |
 +---------------------+-----------+--------------+----------------------+--------------------+
 
-The name (seller) is into this format because seller_ids is a reference to many sellers (so specify the ``|1|``) and the name (seller) is itself a reference to a partner. So we have to specify his ID.
-
-You can also specify a partner reference (who is considered as unique) like this:
+Let's say "ref" is a unique-constrained Char field. For the seller, instead of using its id, let's use its ref.
 
 +---------------------+-----------+--------------+---------------------------+--------------------+
-| id                  | name      | default_code | seller_ids|1|name|ref/key | seller_ids|1|price |
+| id                  | name      | default_code | seller_ids|1|ref#key      | seller_ids|1|price |
 +=====================+===========+==============+===========================+====================+
-| __export__.product1 | Product 1 | PRD1         | partner1-ref              | 10                 |
+| 10                  | Product 1 | PRD1         | partner1-ref              | 10                 |
 +---------------------+-----------+--------------+---------------------------+--------------------+
 
-So this ``/key`` say that Odoo should search for a ``res.partner`` where the ref is the cell's value.
+So this ``#key`` means that Odoo should search for a ``res.partner`` where the ref matches the cell value.
 
-
-It's also possible to update a product (for this example) based on the default_code instead of the ID.
+Lets take another example, instead of using the id, we want to use the product's default_code as key.
 
 +---------------------+-----------+------------------+---------------------------+--------------------+
-| id                  | name      | default_code/key | seller_ids|1|name|ref/key | seller_ids|1|price |
+| id                  | name      | default_code#key | seller_ids|1|ref#key      | seller_ids|1|price |
 +=====================+===========+==================+===========================+====================+
 |                     | Product 1 | PRD1             | partner1-ref              | 10                 |
 +---------------------+-----------+------------------+---------------------------+--------------------+
 
-So Odoo will search the product with the ``default_code`` and update it.
+Odoo will search the product with the matching ``default_code`` and update it.
 
 
 Technically
@@ -149,11 +171,6 @@ Please take care of iterators (``yield``) to avoid loading full file into the sy
 Known issues / Roadmap
 ======================
 
-Problems are related to UI. They are also present in base_export_manager dependency. If entering correct data the first time, the problems can be ignored.
-
-The following issues are closely related and stem from the first one:
-
-* Currently, base_export_manager does not support modifying a line's relational fields (a crash occurs if you try it)
 * Unticking the "Use tab" boolean should clear the previously selected tab_filter_id
 * Changing a line's field should clear the previously selected tab_filter_id
 
@@ -181,6 +198,7 @@ Contributors
 * Chafique Delli <chafique.delli@akretion.com>
 * Sébastien Beau <sebastien.beau@akretion.com>
 * François Honoré (ACSONE SA/NV) <francois.honore@acsone.eu>
+* Kevin Khao <kevin.khao@akretion.com>
 
 Maintainers
 ~~~~~~~~~~~

--- a/pattern_import_export/models/ir_exports.py
+++ b/pattern_import_export/models/ir_exports.py
@@ -141,6 +141,8 @@ class IrExports(models.Model):
                         key = int(key) - 1
                     elif IDENTIFIER_SUFFIX in key:
                         key = key.replace(IDENTIFIER_SUFFIX, "")
+                    if key == ".id":
+                        key = "id"
                     val = val[key]
                     if val is None:
                         break

--- a/pattern_import_export/models/ir_exports_line.py
+++ b/pattern_import_export/models/ir_exports_line.py
@@ -184,6 +184,8 @@ class IrExportsLine(models.Model):
                     header = record.field1_id.field_description
                 else:
                     header = record.field1_id.name
+                    if header == "id":
+                        header = ".id"
                 if record.is_key:
                     header += IDENTIFIER_SUFFIX
                 headers.append(header)

--- a/pattern_import_export/readme/CONFIGURE.rst
+++ b/pattern_import_export/readme/CONFIGURE.rst
@@ -1,0 +1,2 @@
+* Install another module that supports a specific file type
+* Use the Patterns menu to configure your import/export formats

--- a/pattern_import_export/readme/CONTRIBUTORS.rst
+++ b/pattern_import_export/readme/CONTRIBUTORS.rst
@@ -1,3 +1,4 @@
 * Chafique Delli <chafique.delli@akretion.com>
 * Sébastien Beau <sebastien.beau@akretion.com>
 * François Honoré (ACSONE SA/NV) <francois.honore@acsone.eu>
+* Kevin Khao <kevin.khao@akretion.com>

--- a/pattern_import_export/readme/DESCRIPTION.rst
+++ b/pattern_import_export/readme/DESCRIPTION.rst
@@ -1,7 +1,20 @@
-This module allows to create some patterns to export records.
-A pattern is defined by a list of fields to export.
-This module only create a common data structure used to do the real export into the expected format.
+Overview
+~~~~~~~~
 
-The import is also implemented to create or update records.
-Fields to update (or create) shouldn't be necessarily into the pattern (but the base model should match).
-That means if your pattern only contains the name field, you can also update others fields without updating your pattern.
+This module extends the import/export capabilities of Odoo.
+
+Patterns are simply a type of ir.exports model, so you can define them with the native Odoo widget to define export lists.
+
+This module only create a common data structure. Other modules will be used to add specific file type support like excel and csv.
+
+
+Features
+--------
+
+* Key matching: instead of always using IDs, match keys to unique-constrained fields, for example update a product by
+  specifying its product_code instead of its database ID or external ID
+
+* One2many and Many2many support: create or update for example invoice lines with a syntax that is very readable and easy to update
+
+* As long as you respect the appropriate format and field names, you are free to add/remove/rename columns, even if they
+  are not in the initial Pattern used for the export

--- a/pattern_import_export/readme/ROADMAP.rst
+++ b/pattern_import_export/readme/ROADMAP.rst
@@ -1,7 +1,2 @@
-Problems are related to UI. They are also present in base_export_manager dependency. If entering correct data the first time, the problems can be ignored.
-
-The following issues are closely related and stem from the first one:
-
-* Currently, base_export_manager does not support modifying a line's relational fields (a crash occurs if you try it)
 * Unticking the "Use tab" boolean should clear the previously selected tab_filter_id
 * Changing a line's field should clear the previously selected tab_filter_id

--- a/pattern_import_export/readme/USAGE.rst
+++ b/pattern_import_export/readme/USAGE.rst
@@ -1,48 +1,54 @@
-Functionally
-~~~~~~~~~~~~
-To use this module, you only have to install it (please check python dependencies).
-
+Configuring a pattern
+~~~~~~~~~~~~~~~~~~~~~
 First you have to define a pattern:
 
-1. Go on the Import/Export->Patterns menu;
-2. Create your pattern with fields to export.
+1. Go on the Import/Export->Patterns menu
+2. Create your pattern with fields to export
+
+You can refer to the examples in demo data.
 
 
-Do export
+Exporting
 ---------
-On a Tree view, select records to export (or into the Form view) and on the
-"action" options, pick the "Export with pattern".
-On the new wizard, fill the Export pattern to use and click on the "Export button".
+* Open the tree view of any model and tick some record selection boxes.
+* In the sidebar, click on the "Export with Pattern" button
+* Select the pattern that you wish to use, click export and download the generated file.
+* A "Patterned Import/Export" is created, and its job along with it. Depending on the success or failure of the job,
+  you will receive a red/green notification on your window.
 
-A job is now created and your export will be executed as soon as possible (depending on system charge).
 
-Do import
+Importing
 ---------
-Once your file is edited, you can upload it to create or update related records.
+You have two options:
 
-On a Tree view, select at least one record (not necessarily ones to update) and on the "action" button, select "Import with pattern".
-A new wizard is open and select a pattern to do the import.
+* Open the tree view of any model and tick some record selection boxes (for this step, these don't matter, we only just want to show the sidebar).
+* In the sidebar, click on the "Import with Pattern" button
+* Select the pattern that you used to generate the export, upload your file and click import.
+* A "Patterned Import/Export" is created, and its job along with it. Depending on the success or failure of the job, you
+  will receive a red/green notification on your window. You can check the details in the appropriate Import/Export menu.
 
-Into your file, you can add/remove/rename column as you want (with specific format and with existing field's name).
+Or:
 
-You can also add some fields wo aren't into the pattern and these fields' will be updated.
+* Access the Import wizard through the Import/Export menu
+* Select the Pattern that you want to use
+* Click on the "Import" button
 
-To be more user-friendly, it's not mandatory to work with ID or XML ID to update existing record.
-You can just add "/key" at the end of the column name (without spaces) and the column will become the key (please ensure the field used as key as necessary constraints).
+Example
+-------
 
-Example of simple update on ``product.product``:
+Here is an example of a simple update on ``product.product``:
 Existing record:
 
-- xml id: "__export__.product1"
+- id: 10
 - name: "Product 1"
 - default_code: "PRD1"
 
-The generated export should be like
+The generated export will look like:
 
 +---------------------+-----------+--------------+
 | id                  | name      | default_code |
 +=====================+===========+==============+
-| __export__.product1 | Product 1 | PRD1         |
+| 10                  | Product 1 | PRD1         |
 +---------------------+-----------+--------------+
 
 Updated file
@@ -50,53 +56,50 @@ Updated file
 +---------------------+---------------+--------------+
 | id                  | name          | default_code |
 +=====================+===============+==============+
-| __export__.product1 | Product 1-bis | PRD1B        |
+| 10                  | Product 1-bis | PRD1B        |
 +---------------------+---------------+--------------+
 
-Then your record will be updated:
+After import, our record will have been updated:
 
 - xml id: "__export__.product1"
 - name: "Product 1-bis"
 - default_code: "PRD1B"
 
-On the same example, you can also edit more complex fields like relational fields:
+Now, let's update some relational fields. Here is some more of our starting data:
 
 - seller_ids:
 
- - xml id (of the seller/partner): "__export__.partner1"
+ - id (of the seller_id which is a res.partner): 22
  - name (seller): Partner 1
  - price: 10
 
 The generated export should be like
 
 +---------------------+-----------+--------------+----------------------+--------------------+
-| id                  | name      | default_code | seller_ids|1|name|id | seller_ids|1|price |
+| id                  | name      | default_code | seller_ids|1|id      | seller_ids|1|price |
 +=====================+===========+==============+======================+====================+
-| __export__.product1 | Product 1 | PRD1         | __export__.partner1  | 10                 |
+| 10                  | Product 1 | PRD1         | 22                   | 10                 |
 +---------------------+-----------+--------------+----------------------+--------------------+
 
-The name (seller) is into this format because seller_ids is a reference to many sellers (so specify the ``|1|``) and the name (seller) is itself a reference to a partner. So we have to specify his ID.
-
-You can also specify a partner reference (who is considered as unique) like this:
+Let's say "ref" is a unique-constrained Char field. For the seller, instead of using its id, let's use its ref.
 
 +---------------------+-----------+--------------+---------------------------+--------------------+
-| id                  | name      | default_code | seller_ids|1|name|ref/key | seller_ids|1|price |
+| id                  | name      | default_code | seller_ids|1|ref#key      | seller_ids|1|price |
 +=====================+===========+==============+===========================+====================+
-| __export__.product1 | Product 1 | PRD1         | partner1-ref              | 10                 |
+| 10                  | Product 1 | PRD1         | partner1-ref              | 10                 |
 +---------------------+-----------+--------------+---------------------------+--------------------+
 
-So this ``/key`` say that Odoo should search for a ``res.partner`` where the ref is the cell's value.
+So this ``#key`` means that Odoo should search for a ``res.partner`` where the ref matches the cell value.
 
-
-It's also possible to update a product (for this example) based on the default_code instead of the ID.
+Lets take another example, instead of using the id, we want to use the product's default_code as key.
 
 +---------------------+-----------+------------------+---------------------------+--------------------+
-| id                  | name      | default_code/key | seller_ids|1|name|ref/key | seller_ids|1|price |
+| id                  | name      | default_code#key | seller_ids|1|ref#key      | seller_ids|1|price |
 +=====================+===========+==================+===========================+====================+
 |                     | Product 1 | PRD1             | partner1-ref              | 10                 |
 +---------------------+-----------+------------------+---------------------------+--------------------+
 
-So Odoo will search the product with the ``default_code`` and update it.
+Odoo will search the product with the matching ``default_code`` and update it.
 
 
 Technically

--- a/pattern_import_export/static/description/index.html
+++ b/pattern_import_export/static/description/index.html
@@ -368,71 +368,84 @@ ul.auto-toc {
 !! changes will be overwritten.                   !!
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
 <p><a class="reference external" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external" href="https://github.com/shopinvader/pattern-import-export/tree/12.0/pattern_import_export"><img alt="shopinvader/pattern-import-export" src="https://img.shields.io/badge/github-shopinvader%2Fpattern--import--export-lightgray.png?logo=github" /></a></p>
-<p>This module allows to create some patterns to export records.
-A pattern is defined by a list of fields to export.
-This module only create a common data structure used to do the real export into the expected format.</p>
-<p>The import is also implemented to create or update records.
-Fields to update (or create) shouldn’t be necessarily into the pattern (but the base model should match).
-That means if your pattern only contains the name field, you can also update others fields without updating your pattern.</p>
+<div class="section" id="overview">
+<h1>Overview</h1>
+<p>This module extends the import/export capabilities of Odoo.</p>
+<p>Patterns are simply a type of ir.exports model, so you can define them with the native Odoo widget to define export lists.</p>
+<p>This module only create a common data structure. Other modules will be used to add specific file type support like excel and csv.</p>
+<div class="section" id="features">
+<h2>Features</h2>
+<ul class="simple">
+<li>Key matching: instead of always using IDs, match keys to unique-constrained fields, for example update a product by
+specifying its product_code instead of its database ID or external ID</li>
+<li>One2many and Many2many support: create or update for example invoice lines with a syntax that is very readable and easy to update</li>
+<li>As long as you respect the appropriate format and field names, you are free to add/remove/rename columns, even if they
+are not in the initial Pattern used for the export</li>
+</ul>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
-<li><a class="reference internal" href="#usage" id="id1">Usage</a><ul>
-<li><a class="reference internal" href="#functionally" id="id2">Functionally</a><ul>
-<li><a class="reference internal" href="#do-export" id="id3">Do export</a></li>
-<li><a class="reference internal" href="#do-import" id="id4">Do import</a></li>
+<li><a class="reference internal" href="#configuration" id="id1">Configuration</a></li>
+<li><a class="reference internal" href="#usage" id="id2">Usage</a></li>
 </ul>
-</li>
-<li><a class="reference internal" href="#technically" id="id5">Technically</a><ul>
-<li><a class="reference internal" href="#add-a-new-export-format" id="id6">Add a new export format</a></li>
-</ul>
-</li>
-</ul>
-</li>
-<li><a class="reference internal" href="#known-issues-roadmap" id="id7">Known issues / Roadmap</a></li>
-<li><a class="reference internal" href="#bug-tracker" id="id8">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="id9">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="id10">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="id11">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="id12">Maintainers</a></li>
-</ul>
-</li>
+</div>
+<div class="section" id="configuration">
+<h3><a class="toc-backref" href="#id1">Configuration</a></h3>
+<ul class="simple">
+<li>Install another module that supports a specific file type</li>
+<li>Use the Patterns menu to configure your import/export formats</li>
 </ul>
 </div>
 <div class="section" id="usage">
-<h1><a class="toc-backref" href="#id1">Usage</a></h1>
-<div class="section" id="functionally">
-<h2><a class="toc-backref" href="#id2">Functionally</a></h2>
-<p>To use this module, you only have to install it (please check python dependencies).</p>
+<h3><a class="toc-backref" href="#id2">Usage</a></h3>
+</div>
+</div>
+</div>
+<div class="section" id="configuring-a-pattern">
+<h1>Configuring a pattern</h1>
 <p>First you have to define a pattern:</p>
 <ol class="arabic simple">
-<li>Go on the Import/Export-&gt;Patterns menu;</li>
-<li>Create your pattern with fields to export.</li>
+<li>Go on the Import/Export-&gt;Patterns menu</li>
+<li>Create your pattern with fields to export</li>
 </ol>
-<div class="section" id="do-export">
-<h3><a class="toc-backref" href="#id3">Do export</a></h3>
-<p>On a Tree view, select records to export (or into the Form view) and on the
-“action” options, pick the “Export with pattern”.
-On the new wizard, fill the Export pattern to use and click on the “Export button”.</p>
-<p>A job is now created and your export will be executed as soon as possible (depending on system charge).</p>
+<p>You can refer to the examples in demo data.</p>
+<div class="section" id="exporting">
+<h2>Exporting</h2>
+<ul class="simple">
+<li>Open the tree view of any model and tick some record selection boxes.</li>
+<li>In the sidebar, click on the “Export with Pattern” button</li>
+<li>Select the pattern that you wish to use, click export and download the generated file.</li>
+<li>A “Patterned Import/Export” is created, and its job along with it. Depending on the success or failure of the job,
+you will receive a red/green notification on your window.</li>
+</ul>
 </div>
-<div class="section" id="do-import">
-<h3><a class="toc-backref" href="#id4">Do import</a></h3>
-<p>Once your file is edited, you can upload it to create or update related records.</p>
-<p>On a Tree view, select at least one record (not necessarily ones to update) and on the “action” button, select “Import with pattern”.
-A new wizard is open and select a pattern to do the import.</p>
-<p>Into your file, you can add/remove/rename column as you want (with specific format and with existing field’s name).</p>
-<p>You can also add some fields wo aren’t into the pattern and these fields’ will be updated.</p>
-<p>To be more user-friendly, it’s not mandatory to work with ID or XML ID to update existing record.
-You can just add “/key” at the end of the column name (without spaces) and the column will become the key (please ensure the field used as key as necessary constraints).</p>
-<p>Example of simple update on <tt class="docutils literal">product.product</tt>:
+<div class="section" id="importing">
+<h2>Importing</h2>
+<p>You have two options:</p>
+<ul class="simple">
+<li>Open the tree view of any model and tick some record selection boxes (for this step, these don’t matter, we only just want to show the sidebar).</li>
+<li>In the sidebar, click on the “Import with Pattern” button</li>
+<li>Select the pattern that you used to generate the export, upload your file and click import.</li>
+<li>A “Patterned Import/Export” is created, and its job along with it. Depending on the success or failure of the job, you
+will receive a red/green notification on your window. You can check the details in the appropriate Import/Export menu.</li>
+</ul>
+<p>Or:</p>
+<ul class="simple">
+<li>Access the Import wizard through the Import/Export menu</li>
+<li>Select the Pattern that you want to use</li>
+<li>Click on the “Import” button</li>
+</ul>
+</div>
+<div class="section" id="example">
+<h2>Example</h2>
+<p>Here is an example of a simple update on <tt class="docutils literal">product.product</tt>:
 Existing record:</p>
 <ul class="simple">
-<li>xml id: “__export__.product1”</li>
+<li>id: 10</li>
 <li>name: “Product 1”</li>
 <li>default_code: “PRD1”</li>
 </ul>
-<p>The generated export should be like</p>
+<p>The generated export will look like:</p>
 <table border="1" class="docutils">
 <colgroup>
 <col width="46%" />
@@ -446,7 +459,7 @@ Existing record:</p>
 </tr>
 </thead>
 <tbody valign="top">
-<tr><td>__export__.product1</td>
+<tr><td>10</td>
 <td>Product 1</td>
 <td>PRD1</td>
 </tr>
@@ -466,25 +479,25 @@ Existing record:</p>
 </tr>
 </thead>
 <tbody valign="top">
-<tr><td>__export__.product1</td>
+<tr><td>10</td>
 <td>Product 1-bis</td>
 <td>PRD1B</td>
 </tr>
 </tbody>
 </table>
-<p>Then your record will be updated:</p>
+<p>After import, our record will have been updated:</p>
 <ul class="simple">
 <li>xml id: “__export__.product1”</li>
 <li>name: “Product 1-bis”</li>
 <li>default_code: “PRD1B”</li>
 </ul>
-<p>On the same example, you can also edit more complex fields like relational fields:</p>
+<p>Now, let’s update some relational fields. Here is some more of our starting data:</p>
 <ul class="simple">
 <li>seller_ids:</li>
 </ul>
 <blockquote>
 <ul class="simple">
-<li>xml id (of the seller/partner): “__export__.partner1”</li>
+<li>id (of the seller_id which is a res.partner): 22</li>
 <li>name (seller): Partner 1</li>
 <li>price: 10</li>
 </ul>
@@ -502,21 +515,20 @@ Existing record:</p>
 <tr><th class="head">id</th>
 <th class="head">name</th>
 <th class="head">default_code</th>
-<th class="head">seller_ids|1|name|id</th>
+<th class="head">seller_ids|1|id</th>
 <th class="head">seller_ids|1|price</th>
 </tr>
 </thead>
 <tbody valign="top">
-<tr><td>__export__.product1</td>
+<tr><td>10</td>
 <td>Product 1</td>
 <td>PRD1</td>
-<td>__export__.partner1</td>
+<td>22</td>
 <td>10</td>
 </tr>
 </tbody>
 </table>
-<p>The name (seller) is into this format because seller_ids is a reference to many sellers (so specify the <tt class="docutils literal">|1|</tt>) and the name (seller) is itself a reference to a partner. So we have to specify his ID.</p>
-<p>You can also specify a partner reference (who is considered as unique) like this:</p>
+<p>Let’s say “ref” is a unique-constrained Char field. For the seller, instead of using its id, let’s use its ref.</p>
 <table border="1" class="docutils">
 <colgroup>
 <col width="23%" />
@@ -529,12 +541,12 @@ Existing record:</p>
 <tr><th class="head">id</th>
 <th class="head">name</th>
 <th class="head">default_code</th>
-<th class="head">seller_ids|1|name|ref/key</th>
+<th class="head">seller_ids|1|ref#key</th>
 <th class="head">seller_ids|1|price</th>
 </tr>
 </thead>
 <tbody valign="top">
-<tr><td>__export__.product1</td>
+<tr><td>10</td>
 <td>Product 1</td>
 <td>PRD1</td>
 <td>partner1-ref</td>
@@ -542,8 +554,8 @@ Existing record:</p>
 </tr>
 </tbody>
 </table>
-<p>So this <tt class="docutils literal">/key</tt> say that Odoo should search for a <tt class="docutils literal">res.partner</tt> where the ref is the cell’s value.</p>
-<p>It’s also possible to update a product (for this example) based on the default_code instead of the ID.</p>
+<p>So this <tt class="docutils literal">#key</tt> means that Odoo should search for a <tt class="docutils literal">res.partner</tt> where the ref matches the cell value.</p>
+<p>Lets take another example, instead of using the id, we want to use the product’s default_code as key.</p>
 <table border="1" class="docutils">
 <colgroup>
 <col width="22%" />
@@ -555,8 +567,8 @@ Existing record:</p>
 <thead valign="bottom">
 <tr><th class="head">id</th>
 <th class="head">name</th>
-<th class="head">default_code/key</th>
-<th class="head">seller_ids|1|name|ref/key</th>
+<th class="head">default_code#key</th>
+<th class="head">seller_ids|1|ref#key</th>
 <th class="head">seller_ids|1|price</th>
 </tr>
 </thead>
@@ -569,34 +581,28 @@ Existing record:</p>
 </tr>
 </tbody>
 </table>
-<p>So Odoo will search the product with the <tt class="docutils literal">default_code</tt> and update it.</p>
+<p>Odoo will search the product with the matching <tt class="docutils literal">default_code</tt> and update it.</p>
 </div>
 </div>
 <div class="section" id="technically">
-<h2><a class="toc-backref" href="#id5">Technically</a></h2>
+<h1>Technically</h1>
 <div class="section" id="add-a-new-export-format">
-<h3><a class="toc-backref" href="#id6">Add a new export format</a></h3>
+<h2>Add a new export format</h2>
 <ol class="arabic simple">
 <li>Inherit the <tt class="docutils literal">ir.exports</tt> model.</li>
 <li>Add your new file format in the selection field <tt class="docutils literal">export_format</tt>;</li>
 <li>Implements functions <tt class="docutils literal">_export_with_record_&lt;format&gt;</tt> and <tt class="docutils literal">_read_import_data_&lt;format&gt;</tt>.</li>
 </ol>
 <p>Please take care of iterators (<tt class="docutils literal">yield</tt>) to avoid loading full file into the system memory.</p>
-</div>
-</div>
-</div>
 <div class="section" id="known-issues-roadmap">
-<h1><a class="toc-backref" href="#id7">Known issues / Roadmap</a></h1>
-<p>Problems are related to UI. They are also present in base_export_manager dependency. If entering correct data the first time, the problems can be ignored.</p>
-<p>The following issues are closely related and stem from the first one:</p>
+<h3>Known issues / Roadmap</h3>
 <ul class="simple">
-<li>Currently, base_export_manager does not support modifying a line’s relational fields (a crash occurs if you try it)</li>
 <li>Unticking the “Use tab” boolean should clear the previously selected tab_filter_id</li>
 <li>Changing a line’s field should clear the previously selected tab_filter_id</li>
 </ul>
 </div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#id8">Bug Tracker</a></h1>
+<h3>Bug Tracker</h3>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/shopinvader/pattern-import-export/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us smashing it by providing a detailed and welcomed
@@ -604,26 +610,29 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#id9">Credits</a></h1>
+<h3>Credits</h3>
+</div>
+</div>
+</div>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#id10">Authors</a></h2>
+<h1>Authors</h1>
 <ul class="simple">
 <li>Akretion</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#id11">Contributors</a></h2>
+<h1>Contributors</h1>
 <ul class="simple">
 <li>Chafique Delli &lt;<a class="reference external" href="mailto:chafique.delli&#64;akretion.com">chafique.delli&#64;akretion.com</a>&gt;</li>
 <li>Sébastien Beau &lt;<a class="reference external" href="mailto:sebastien.beau&#64;akretion.com">sebastien.beau&#64;akretion.com</a>&gt;</li>
 <li>François Honoré (ACSONE SA/NV) &lt;<a class="reference external" href="mailto:francois.honore&#64;acsone.eu">francois.honore&#64;acsone.eu</a>&gt;</li>
+<li>Kevin Khao &lt;<a class="reference external" href="mailto:kevin.khao&#64;akretion.com">kevin.khao&#64;akretion.com</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#id12">Maintainers</a></h2>
+<h1>Maintainers</h1>
 <p>This module is part of the <a class="reference external" href="https://github.com/shopinvader/pattern-import-export/tree/12.0/pattern_import_export">shopinvader/pattern-import-export</a> project on GitHub.</p>
 <p>You are welcome to contribute.</p>
-</div>
 </div>
 </div>
 </body>


### PR DESCRIPTION
Because of issues, in the current module functionality, we must only consider in-DB ids, not external IDs. Here are the issues with extids:

exporting them is hard (can not set field directly in ir.exports window),
importing them is hard (confusion between id/.id),
native Odoo export widget that allows us to select fields is broken and does not allow selection of DB ID (.id), it raises because of a naive check that sees ".id" column doesn't actually exist
This is a temporary measure and should be fixed later on.